### PR TITLE
fix flattenSpec field names

### DIFF
--- a/supervisor_types.go
+++ b/supervisor_types.go
@@ -106,7 +106,7 @@ type FieldList []Field
 type Field struct {
 	Type string `json:"type"`
 	Name string `json:"name"`
-	Expr string `json:"expression"`
+	Expr string `json:"expr"`
 }
 
 // Transform defines a single filed transformation of the TransformSpec.
@@ -371,20 +371,10 @@ func defaultKafkaIngestionSpec() *InputIngestionSpec {
 				Format: "auto",
 			},
 			TransformSpec: &TransformSpec{
-				Transforms: []Transform{
-					{
-						Type: "expression",
-						Name: "payload",
-						Expr: "parse_json(payload)",
-					},
-				},
+				Transforms: []Transform{},
 			},
 			DimensionsSpec: &DimensionsSpec{
-				Dimensions: DimensionSet{
-					"id",
-					"ts",
-					"payload",
-				},
+				Dimensions: DimensionSet{},
 			},
 			GranularitySpec: &GranularitySpec{
 				Type:               "uniform",
@@ -399,7 +389,7 @@ func defaultKafkaIngestionSpec() *InputIngestionSpec {
 			InputFormat: &InputFormat{
 				Type: "json",
 			},
-			TaskDuration: "PT30M",
+			TaskDuration: "PT1H",
 			ConsumerProperties: &ConsumerProperties{
 				BootstrapServers: "",
 			},

--- a/supervisor_types_test.go
+++ b/supervisor_types_test.go
@@ -63,13 +63,7 @@ var jsonBasic = `{
             "format": "auto"
         },
         "transformSpec": {
-            "transforms": [
-                {
-                    "type": "expression",
-                    "name": "payload",
-                    "expression": "parse_json(payload)"
-                }
-            ]
+            "transforms": []
         },
         "dimensionsSpec": {
             "dimensions": [
@@ -89,7 +83,7 @@ var jsonBasic = `{
         "consumerProperties": {
             "bootstrap.servers": "test_brokers"
         },
-        "taskDuration": "PT30M",
+        "taskDuration": "PT1H",
         "useEarliestOffset": false,
         "flattenSpec": {
             "fields": []


### PR DESCRIPTION
* Fix flattenSpec field names (`expression` -> `expr`)
* Fix default for the whole spec to make it more agnostic to the consumers.