### PR TITLE
add detailed dimension specification

### DIFF
--- a/supervisor_types.go
+++ b/supervisor_types.go
@@ -1,6 +1,8 @@
 package druid
 
-import "time"
+import (
+	"time"
+)
 
 // InputIngestionSpec is the root-level type defining an ingestion spec used
 // by Apache Druid.
@@ -127,7 +129,12 @@ type SpatialDimension struct {
 type TransformSet []Transform
 
 // DimensionSet is a unique set of druid datasource dimensions(labels).
-type DimensionSet []string
+type DimensionSet []interface{}
+
+type Dimension struct {
+	Type string `json:"type"`
+	Name string `json:"name"`
+}
 
 // SpatialDimensionSet is a unique set of druid datasource spatial dimensions.
 type SpatialDimensionSet []SpatialDimension

--- a/supervisor_types.go
+++ b/supervisor_types.go
@@ -1,9 +1,5 @@
 package druid
 
-import (
-	"time"
-)
-
 // InputIngestionSpec is the root-level type defining an ingestion spec used
 // by Apache Druid.
 type InputIngestionSpec struct {
@@ -129,8 +125,9 @@ type SpatialDimension struct {
 type TransformSet []Transform
 
 // DimensionSet is a unique set of druid datasource dimensions(labels).
-type DimensionSet []interface{}
+type DimensionSet []any
 
+// Dimension is a typed definition of a datasource dimension.
 type Dimension struct {
 	Type string `json:"type"`
 	Name string `json:"name"`
@@ -348,7 +345,7 @@ type SupervisorStatusPayload struct {
 // with the response metadata.
 type SupervisorStatus struct {
 	SupervisorId   string                   `json:"id"`
-	GenerationTime time.Time                `json:"generationTime"`
+	GenerationTime string                   `json:"generationTime"`
 	Payload        *SupervisorStatusPayload `json:"payload"`
 }
 

--- a/supervisor_types_test.go
+++ b/supervisor_types_test.go
@@ -35,11 +35,11 @@ func TestKafkaIngestionSpec(t *testing.T) {
 		{
 			name: "set labels",
 			options: []IngestionSpecOptions{
-				SetDimensions([]interface{}{"ts", "user_name", "payload"}),
+				SetDimensions([]any{"ts", "user_name", "payload"}),
 			},
 			expected: func() *InputIngestionSpec {
 				out := defaultKafkaIngestionSpec()
-				out.DataSchema.DimensionsSpec.Dimensions = []interface{}{"ts", "user_name", "payload"}
+				out.DataSchema.DimensionsSpec.Dimensions = []any{"ts", "user_name", "payload"}
 				return out
 			}(),
 		},
@@ -101,7 +101,7 @@ func TestKafkaIngestionSpec_MarshalJSON(t *testing.T) {
 			SetDataSource("test_datasource"),
 			SetTopic("test_topic"),
 			SetBrokers("test_brokers"),
-			SetDimensions([]interface{}{"ts", "user_name", "payload"}),
+			SetDimensions([]any{"ts", "user_name", "payload"}),
 		)
 		actual, err := json.MarshalIndent(spec, "", "    ")
 		if err != nil {
@@ -170,7 +170,7 @@ func TestIngestionSpecWithTypedDimensions_MarshalJSON(t *testing.T) {
 			SetDataSource("test_datasource"),
 			SetTopic("test_topic"),
 			SetBrokers("test_brokers"),
-			SetDimensions([]interface{}{
+			SetDimensions([]any{
 				Dimension{Type: "string", Name: "ts"},
 				Dimension{Type: "json", Name: "payload"},
 			}),


### PR DESCRIPTION
Add detailed dimension specification that allows to specify types of the dimensions (previously unsupported). It is necessary in order for us to support json columns that could be then passed into the flattening spec for flattening the schema.  Streaming spec sample with json columns:  https://druid.apache.org/docs/latest/querying/nested-columns/#streaming-ingestion