### PR TITLE
add fields for druid input source

### DIFF
--- a/common_spec_types.go
+++ b/common_spec_types.go
@@ -332,6 +332,12 @@ type InputSource struct {
 	// SqlInputSource.
 	SQLs     []string  `json:"sqls,omitempty"`
 	Database *Database `json:"database,omitempty"`
+
+	// Druid input source
+	Datasource string `json:"dataSource,omitempty"`
+	// ISO-8601 interval, which defines the time range to fetch the data over.
+	Interval string   `json:"interval,omitempty"`
+	Metrics  []string `json:"metrics,omitempty"`
 }
 
 // TransformSpec is responsible for transforming druid input data

--- a/common_spec_types.go
+++ b/common_spec_types.go
@@ -333,7 +333,7 @@ type InputSource struct {
 	SQLs     []string  `json:"sqls,omitempty"`
 	Database *Database `json:"database,omitempty"`
 
-	// Druid input source
+	// Druid input source.
 	Datasource string `json:"dataSource,omitempty"`
 	// ISO-8601 interval, which defines the time range to fetch the data over.
 	Interval string   `json:"interval,omitempty"`


### PR DESCRIPTION
Add fields necessary for druid->druid ingestion. This is a part of the bigger https://github.com/h2oai/telemetry/pull/234 implementation.