### PR TITLE
Added TaskIngestionSpecOptions functions to define druid reindexing task

### DIFF
--- a/task_types.go
+++ b/task_types.go
@@ -65,7 +65,7 @@ func defaultTaskIngestionSpec() *TaskIngestionSpec {
 			IOConfig: &IOConfig{
 				Type:        "index_parallel",
 				InputSource: &InputSource{},
-				// InputFormat: &InputFormat{},
+				InputFormat: &InputFormat{},
 			},
 			TuningConfig: &TuningConfig{
 				Type: "index_parallel",

--- a/task_types.go
+++ b/task_types.go
@@ -65,7 +65,7 @@ func defaultTaskIngestionSpec() *TaskIngestionSpec {
 			IOConfig: &IOConfig{
 				Type:        "index_parallel",
 				InputSource: &InputSource{},
-				InputFormat: &InputFormat{},
+				// InputFormat: &InputFormat{},
 			},
 			TuningConfig: &TuningConfig{
 				Type: "index_parallel",

--- a/task_types.go
+++ b/task_types.go
@@ -5,6 +5,10 @@ import (
 	"time"
 )
 
+const (
+	iso8601Format = "2006-01-02T15:04:05"
+)
+
 // TaskStatusResponse is a response object containing status of a task.
 type TaskStatusResponse struct {
 	Task   string     `json:"task"`
@@ -178,8 +182,8 @@ func SetTaskDruidInputSource(datasource string, startTime time.Time, endTime tim
 			Datasource: datasource,
 			Interval: fmt.Sprintf(
 				"%s/%s",
-				startTime.Format("2006-01-02T15:04:05"),
-				endTime.Format("2006-01-02T15:04:05"),
+				startTime.Format(iso8601Format),
+				endTime.Format(iso8601Format),
 			),
 		}
 	}

--- a/task_types_test.go
+++ b/task_types_test.go
@@ -1,0 +1,57 @@
+package druid
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTaskIngestionSpec(t *testing.T) {
+	var testData = []struct {
+		name     string
+		options  []TaskIngestionSpecOptions
+		expected *TaskIngestionSpec
+	}{
+		{
+			name: "druid reindex ingestion task",
+			options: []TaskIngestionSpecOptions{
+				SetTaskDataSource("telemetry-test"),
+				SetTaskDataDimensions(DimensionSet{{"id"}, {"kind"}, {"test"}}),
+				SetTaskDruidInputSource(
+					"telemetry-test",
+					time.Date(2023, 12, 12, 0, 0, 0, 0, time.UTC),
+					time.Date(2023, 12, 24, 0, 0, 0, 0, time.UTC),
+				),
+				SetTaskSchemaDiscovery(false),
+				SetTaskTimestampColumn("__time"),
+				SetTaskGranularitySpec("DAY", &QueryGranularitySpec{"none"}, true),
+			},
+			expected: func() *TaskIngestionSpec {
+				out := NewTaskIngestionSpec()
+				out.Spec.DataSchema.DataSource = "telemetry-test"
+				out.Spec.DataSchema.DimensionsSpec = &DimensionsSpec{
+					Dimensions: DimensionSet{{"id"}, {"kind"}, {"test"}},
+				}
+				out.Spec.IOConfig.InputSource.Type = "druid"
+				out.Spec.IOConfig.InputSource.Datasource = "telemetry-test"
+				out.Spec.IOConfig.InputSource.Interval = "2023-12-12T00:00:00/2023-12-24T00:00:00"
+				out.Spec.DataSchema.TimeStampSpec.Column = "__time"
+				out.Spec.DataSchema.TimeStampSpec.Format = "auto"
+				out.Spec.DataSchema.GranularitySpec.SegmentGranularity = "DAY"
+				out.Spec.DataSchema.GranularitySpec.QueryGranularity = &QueryGranularitySpec{"none"}
+				out.Spec.DataSchema.GranularitySpec.Rollup = true
+				return out
+			}(),
+		},
+	}
+
+	for _, test := range testData {
+		t.Run(test.name, func(t *testing.T) {
+			actual := NewTaskIngestionSpec(
+				test.options...,
+			)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
This PR defines more `TaskIngestionSpecOptions` in order to properly submit druid reindexing task.
Additionally default task ingestion spec is changed to hold ingestion type agnostic default values.