### PR TITLE
Always include rollup field

### DIFF
--- a/common_spec_types.go
+++ b/common_spec_types.go
@@ -148,7 +148,7 @@ type GranularitySpec struct {
 	Type               string                `json:"type"`
 	SegmentGranularity string                `json:"segmentGranularity,omitempty"`
 	QueryGranularity   *QueryGranularitySpec `json:"queryGranularity,omitempty"`
-	Rollup             bool                  `json:"rollup,omitempty"`
+	Rollup             bool                  `json:"rollup"`
 	Intervals          []string              `json:"intervals,omitempty"`
 }
 

--- a/supervisor_types_test.go
+++ b/supervisor_types_test.go
@@ -80,7 +80,8 @@ var jsonBasic = `{
         "granularitySpec": {
 			"type": "uniform",
             "segmentGranularity": "DAY",
-            "queryGranularity":  "none"
+            "queryGranularity":  "none",
+            "rollup": false
         }
     },
     "ioConfig": {
@@ -151,7 +152,8 @@ var jsonWithTypedDimensions = `{
         "granularitySpec": {
 			"type": "uniform",
             "segmentGranularity": "DAY",
-            "queryGranularity": "none"
+            "queryGranularity": "none",
+            "rollup": false
         }
     },
     "ioConfig": {
@@ -209,7 +211,8 @@ var jsonWithSqlInputSource = `{
         "granularitySpec": {
 			"type": "uniform",
 			"segmentGranularity": "DAY",
-            "queryGranularity": "none"
+            "queryGranularity": "none",
+            "rollup": false
         }
     },
     "ioConfig": {


### PR DESCRIPTION
This PR fixes a bug where submitting a task with `rollup=false` was not possible as bool field set to `false` was treated as empty by json marshaller.