### PR TITLE
Introduced GetRunningTasks endpoint

### DIFF
--- a/task_types.go
+++ b/task_types.go
@@ -44,6 +44,22 @@ type TaskIngestionSpec struct {
 	Spec *IngestionSpecData `json:"spec"`
 }
 
+// RunningTask defines running task returned by GetRunningTasks method.
+// https://druid.apache.org/docs/latest/api-reference/tasks-api#sample-response-2
+type RunningTask struct {
+	ID         string `json:"id"`
+	Type       string `json:"type"`
+	Status     string `json:"status"`
+	Datasource string `json:"dataSource"`
+}
+
+// RunningTasksOptions defines supported options which can be passed to GetRunningTasks method.
+// https://druid.apache.org/docs/latest/api-reference/tasks-api#query-parameters-2
+type RunningTasksOptions struct {
+	Datasource string `url:"datasource"`
+	Type       string `url:"type"`
+}
+
 // defaultTaskIngestionSpec returns a default TaskIngestionSpec with basic ingestion
 // specification fields initialized.
 func defaultTaskIngestionSpec() *TaskIngestionSpec {
@@ -160,9 +176,11 @@ func SetTaskIOConfigType(typ string) TaskIngestionSpecOptions {
 // SetTaskInputFormat configures input format for the task based ingestion.
 func SetTaskInputFormat(typ string, findColumnsHeader string, columns []string) TaskIngestionSpecOptions {
 	return func(spec *TaskIngestionSpec) {
-		spec.Spec.IOConfig.InputFormat.Type = typ
-		spec.Spec.IOConfig.InputFormat.FindColumnsFromHeader = findColumnsHeader
-		spec.Spec.IOConfig.InputFormat.Columns = columns
+		spec.Spec.IOConfig.InputFormat = &InputFormat{
+			Type:                  typ,
+			FindColumnsFromHeader: findColumnsHeader,
+			Columns:               columns,
+		}
 	}
 }
 

--- a/task_types.go
+++ b/task_types.go
@@ -176,11 +176,9 @@ func SetTaskIOConfigType(typ string) TaskIngestionSpecOptions {
 // SetTaskInputFormat configures input format for the task based ingestion.
 func SetTaskInputFormat(typ string, findColumnsHeader string, columns []string) TaskIngestionSpecOptions {
 	return func(spec *TaskIngestionSpec) {
-		spec.Spec.IOConfig.InputFormat = &InputFormat{
-			Type:                  typ,
-			FindColumnsFromHeader: findColumnsHeader,
-			Columns:               columns,
-		}
+		spec.Spec.IOConfig.InputFormat.Type = typ
+		spec.Spec.IOConfig.InputFormat.FindColumnsFromHeader = findColumnsHeader
+		spec.Spec.IOConfig.InputFormat.Columns = columns
 	}
 }
 

--- a/tasks.go
+++ b/tasks.go
@@ -1,6 +1,9 @@
 package druid
 
-import "strings"
+import (
+	"net/http"
+	"strings"
+)
 
 const (
 	tasksEndpoint             = "druid/indexer/v1/tasks"
@@ -81,4 +84,19 @@ func (s *TasksService) Shutdown(taskId string) (string, error) {
 
 func applyTaskId(input string, taskId string) string {
 	return strings.Replace(input, ":taskId", taskId, 1)
+}
+
+// GetRunningTasks calls druid task service's running tasks API.
+// https://druid.apache.org/docs/latest/api-reference/tasks-api#get-an-array-of-running-tasks
+func (s *TasksService) GetRunningTasks(options RunningTasksOptions) ([]*RunningTask, error) {
+	r, err := s.client.NewRequest(http.MethodGet, tasksRunningEndpoint, options)
+	var result []*RunningTask
+	if err != nil {
+		return nil, err
+	}
+	_, err = s.client.Do(r, &result)
+	if err != nil {
+		return result, err
+	}
+	return result, nil
 }

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -188,6 +188,10 @@ func (s *TasksServiceTestSuite) TestTerminate() {
 	shutdownTaskID, err := s.client.Tasks().Shutdown(taskID)
 	s.Require().NoError(err, "error should be nil")
 	s.Require().Equal(shutdownTaskID, taskID)
+
+	status, err := s.client.Tasks().GetStatus(taskID)
+	s.Require().NoError(err)
+	s.Require().Equal(status.Status.Status, "FAILED")
 }
 
 func (s *TasksServiceTestSuite) TestGetRunningTasks() {


### PR DESCRIPTION
This PR adds the implementation of `GetRunningTasks` endpoint to support reindexing task orchestration on telemetry server side.