### PR TITLE
Bump druid version to 28.0.1

### DIFF
--- a/testdata/docker-compose.yaml
+++ b/testdata/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       - ZOO_MY_ID=1
 
   coordinator:
-    image: apache/druid:25.0.0
+    image: apache/druid:28.0.1
     container_name: coordinator
     volumes:
       - druid_shared:/opt/shared
@@ -65,7 +65,7 @@ services:
       - environment
 
   broker:
-    image: apache/druid:25.0.0
+    image: apache/druid:28.0.1
     container_name: broker
     volumes:
       - broker_var:/opt/druid/var
@@ -81,7 +81,7 @@ services:
       - environment
 
   historical:
-    image: apache/druid:25.0.0
+    image: apache/druid:28.0.1
     container_name: historical
     volumes:
       - druid_shared:/opt/shared
@@ -98,7 +98,7 @@ services:
       - environment
 
   middlemanager:
-    image: apache/druid:25.0.0
+    image: apache/druid:28.0.1
     container_name: middlemanager
     volumes:
       - druid_shared:/opt/shared
@@ -116,7 +116,7 @@ services:
       - environment
 
   router:
-    image: apache/druid:25.0.0
+    image: apache/druid:28.0.1
     container_name: router
     volumes:
       - router_var:/opt/druid/var


### PR DESCRIPTION
This PR bumps druid version to 28.0.1 to match version which is going to be a part of release.