### PR TITLE
Mapped forceGuaranteedRollup parameter

### DIFF
--- a/common_spec_types.go
+++ b/common_spec_types.go
@@ -38,6 +38,7 @@ type TuningConfig struct {
 	MaxRowsPerSegment                int        `json:"maxRowsPerSegment,omitempty"`
 	MaxRowsInMemory                  int        `json:"maxRowsInMemory,omitempty"`
 	IndexSpecForIntermediatePersists *IndexSpec `json:"indexSpecForIntermediatePersists,omitempty"`
+	ForceGuaranteedRollup            bool       `json:"forceGuaranteedRollup,omitempty"`
 }
 
 // Metric is a Druid aggregator that is applied at ingestion time.

--- a/task_types.go
+++ b/task_types.go
@@ -224,6 +224,14 @@ func SetTaskGranularitySpec(segmentGranularity string, queryGranularity *QueryGr
 	}
 }
 
+// SetForceGuaranteedRollup sets guaranteed rollup setting for ingestion spec.
+// https://druid.apache.org/docs/latest/ingestion/rollup#perfect-rollup-vs-best-effort-rollup
+func SetForceGuaranteedRollup(rollup bool) TaskIngestionSpecOptions {
+	return func(spec *TaskIngestionSpec) {
+		spec.Spec.TuningConfig.ForceGuaranteedRollup = rollup
+	}
+}
+
 // NewTaskIngestionSpec returns a default TaskIngestionSpec and applies any options passed to it.
 func NewTaskIngestionSpec(options ...TaskIngestionSpecOptions) *TaskIngestionSpec {
 	spec := defaultTaskIngestionSpec()

--- a/task_types_test.go
+++ b/task_types_test.go
@@ -26,6 +26,7 @@ func TestTaskIngestionSpec(t *testing.T) {
 				SetTaskSchemaDiscovery(false),
 				SetTaskTimestampColumn("__time"),
 				SetTaskGranularitySpec("DAY", &QueryGranularitySpec{"none"}, true),
+				SetForceGuaranteedRollup(true),
 			},
 			expected: func() *TaskIngestionSpec {
 				out := NewTaskIngestionSpec()
@@ -41,6 +42,7 @@ func TestTaskIngestionSpec(t *testing.T) {
 				out.Spec.DataSchema.GranularitySpec.SegmentGranularity = "DAY"
 				out.Spec.DataSchema.GranularitySpec.QueryGranularity = &QueryGranularitySpec{"none"}
 				out.Spec.DataSchema.GranularitySpec.Rollup = true
+				out.Spec.TuningConfig.ForceGuaranteedRollup = true
 				return out
 			}(),
 		},


### PR DESCRIPTION
Ingestion tasks performs rollup at best effort strategy by default, though in can be configured for perfect rollup via tuning config. For deduplication purposes, perfect rollup is preffered as it guarantees deduplication.