### PR TITLE
Add dynamic config providers for IOConfig ConsumerProperties

### DIFF
--- a/common_spec_types.go
+++ b/common_spec_types.go
@@ -414,7 +414,7 @@ func (p *DynamicConfigProvider) UnmarshalJSON(b []byte) error {
 		p.Value = mcp
 		return nil
 	}
-	return fmt.Errorf("unsupported query granularity: %s", b)
+	return fmt.Errorf("unsupported dynamic config provider: %s", b)
 }
 
 func (p *DynamicConfigProvider) MarshalJSON() ([]byte, error) {

--- a/supervisor_types.go
+++ b/supervisor_types.go
@@ -230,6 +230,18 @@ func SetGranularitySpec(segmentGranularity string, queryGranularity *QueryGranul
 	}
 }
 
+func SetEnvironmentDynamicConfigProvider(dynamicConfig EnvironmentVariableDynamicConfigProvider) IngestionSpecOptions {
+	return func(spec *InputIngestionSpec) {
+		spec.IOConfig.ConsumerProperties.DruidDynamicConfigProvider = &DynamicConfigProvider{dynamicConfig}
+	}
+}
+
+func SetMapStringDynamicConfigProvider(dynamicConfig MapStringDynamicConfigProvider) IngestionSpecOptions {
+	return func(spec *InputIngestionSpec) {
+		spec.IOConfig.ConsumerProperties.DruidDynamicConfigProvider = &DynamicConfigProvider{dynamicConfig}
+	}
+}
+
 // SetSQLInputSource configures sql input source.
 func SetSQLInputSource(dbType, connectURI, user, password string, sqls []string) IngestionSpecOptions {
 	return func(spec *InputIngestionSpec) {


### PR DESCRIPTION
Add dynamic config providers for IOConfig ConsumerProperties to be used in Kafka ingestion spec for supervisor.